### PR TITLE
Add Terraform configs for LDAP monitoring

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,47 @@
+# ThousandEyes LDAP Monitoring Terraform Module
+
+This directory contains Terraform configuration files that automate LDAP monitoring using ThousandEyes. The code creates a reusable transaction test template from `ldap-monitor.js`, sets up minimal permissions, and deploys individual tests with alerting for any number of LDAP servers.
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/) installed.
+- Access to a ThousandEyes account.
+- **Initial setup requirement:** the API token used for the first `terraform apply` must belong to a user with permissions to create roles and groups (for example, a user with the `Account Admin` role).
+
+## Configuration
+
+Create a `terraform.tfvars` file in this directory and populate the required variables:
+
+```hcl
+te_api_token = "<your-api-token>"
+te_user_email = "user@example.com"
+
+ldap_servers = [
+  {
+    name     = "Primary LDAP Server (DC1)"
+    hostname = "ldaps://dc1.example.com"
+    port     = 636
+  },
+  {
+    name     = "Secondary LDAP Server (DC2)"
+    hostname = "ldaps://dc2.example.com"
+    port     = 636
+  }
+]
+
+agent_ids = ["123", "456"]
+```
+
+## Usage
+
+Initialize and apply the configuration:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+## Post-Deployment Recommendation
+
+Following the principle of least privilege, add your primary user or a dedicated service account to the newly created `ThousandEyes Monitoring Config` group after the initial deployment. Generate a new API token from that user and use it for future Terraform runs.

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -1,0 +1,15 @@
+resource "thousandeyes_alert_rule" "ldap_alert_rule" {
+  rule_name  = "LDAP Transaction Failure"
+  alert_type = "TRANSACTION"
+  expression = "( ( num-errors >= 3 ) )"
+}
+
+resource "thousandeyes_transaction_test" "ldap_test" {
+  for_each   = { for server in var.ldap_servers : server.name => server }
+
+  test_name  = "LDAP Check - ${each.value.name}"
+  template_id = thousandeyes_transaction_test.ldap_template.id
+  alert_rules = [thousandeyes_alert_rule.ldap_alert_rule.id]
+  server      = "${each.value.hostname}:${each.value.port}"
+  agents      = var.agent_ids
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,15 @@
+output "monitoring_group_id" {
+  value = thousandeyes_group.monitoring_config.id
+}
+
+output "monitoring_role_id" {
+  value = thousandeyes_role.monitoring_config_admin.id
+}
+
+output "ldap_alert_rule_id" {
+  value = thousandeyes_alert_rule.ldap_alert_rule.id
+}
+
+output "ldap_test_ids" {
+  value = { for name, test in thousandeyes_transaction_test.ldap_test : name => test.id }
+}

--- a/terraform/permissions.tf
+++ b/terraform/permissions.tf
@@ -1,0 +1,15 @@
+resource "thousandeyes_role" "monitoring_config_admin" {
+  name        = "Monitoring Config Administrator"
+  description = "Role for managing LDAP monitoring resources"
+  permissions = [
+    "Edit tests",
+    "Edit alert rules",
+    "Edit test templates",
+    "View all agents"
+  ]
+}
+
+resource "thousandeyes_group" "monitoring_config" {
+  name  = "ThousandEyes Monitoring Config"
+  roles = [thousandeyes_role.monitoring_config_admin.id]
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    thousandeyes = {
+      source  = "thousandeyes/thousandeyes"
+      version = "~> 0.16.0"
+    }
+  }
+}
+
+provider "thousandeyes" {
+  auth_token = var.te_api_token
+}

--- a/terraform/template.tf
+++ b/terraform/template.tf
@@ -1,0 +1,6 @@
+resource "thousandeyes_transaction_test" "ldap_template" {
+  test_name = "LDAP Monitor Template"
+  template  = true
+  script    = file("${path.module}/../ldap-monitor.js")
+  interval  = 300
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,36 @@
+variable "te_api_token" {
+  description = "API token for ThousandEyes user"
+  type        = string
+  sensitive   = true
+}
+
+variable "te_user_email" {
+  description = "Email address associated with API token"
+  type        = string
+}
+
+variable "ldap_servers" {
+  description = "A list of LDAP servers to monitor."
+  type = list(object({
+    name     = string
+    hostname = string
+    port     = number
+  }))
+  default = [
+    {
+      name     = "Primary LDAP Server (DC1)"
+      hostname = "ldaps://dc1.example.com"
+      port     = 636
+    },
+    {
+      name     = "Secondary LDAP Server (DC2)"
+      hostname = "ldaps://dc2.example.com"
+      port     = 636
+    }
+  ]
+}
+
+variable "agent_ids" {
+  description = "List of ThousandEyes agent IDs to run the tests"
+  type        = list(string)
+}


### PR DESCRIPTION
## Summary
- add Terraform code to automate LDAP monitoring
- document deployment instructions

## Testing
- `npm test`
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_6872af6a80f08321b1f65ef1191ea848