### PR TITLE
Update Terraform configuration for ThousandEyes API v7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,20 @@ coverage/
 *.tmp
 *.bak
 *~ 
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+.terraformrc
+terraform.rc
+*.tfplan
+*.tfplan.*
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json 

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/thousandeyes/thousandeyes" {
+  version     = "3.0.5"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:j546ZsWad4xv0m6wb2N/gZQloRyAerAuoYFsZCinvNc=",
+    "zh:33593778f47cd0928dd21483f46a5bf1b1b4ae2a379b33dcaf023d6dd91c1620",
+    "zh:6173e0d3f1bb3ee1e4ce5a838ecc262b9122587fbc602aed4b3c67416a922c65",
+    "zh:7ede9b2f129ef24352057c47b0238a5d9d836d484ecd795e82bfa77ae641019b",
+    "zh:9708037dbdc4373631f0f374e6b11ff69d77dcdfe29bab18c4c3ea2dffeabf21",
+    "zh:9e5916310ef61929ce9181e1e5c49bfaad188aa0b99ea86b1aaa360649133e7c",
+    "zh:9feef41ed0b7691f26e1007dac23eaddb4bf7dbc4cb8e59d6d28afb1c4361659",
+    "zh:bc3497fb7b6bbf17edc84f15600b10d75304b0a35bccdb5cbd9dfcda670084b8",
+    "zh:c579899e0a5cc5ae3203ea943bc42ada9e2c96b5468bc8f71ecc8dd8d4166fb5",
+    "zh:cd930cf24794acb9b09b9fe8c80271a4fc5a007a50190bfa3df665494fa2fb6e",
+    "zh:d760b4aa124ac5f95be9102ff56006ae69cb256413dbdfb136a7dbb75dd78e89",
+    "zh:e385eec922837031e5c997adf0ffca9e76aa0f3f96f9958ffd65e98239dfb9d5",
+  ]
+}

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -1,15 +1,18 @@
 resource "thousandeyes_alert_rule" "ldap_alert_rule" {
-  rule_name  = "LDAP Transaction Failure"
-  alert_type = "TRANSACTION"
-  expression = "( ( num-errors >= 3 ) )"
+  rule_name                 = "LDAP Transaction Failure"
+  alert_type                = "web-transaction"
+  expression                = "( ( num-errors >= 3 ) )"
+  rounds_violating_required = 2
+  rounds_violating_out_of   = 5
 }
 
-resource "thousandeyes_transaction_test" "ldap_test" {
-  for_each   = { for server in var.ldap_servers : server.name => server }
+resource "thousandeyes_web_transaction" "ldap_test" {
+  for_each = { for server in var.ldap_servers : server.name => server }
 
-  test_name  = "LDAP Check - ${each.value.name}"
-  template_id = thousandeyes_transaction_test.ldap_template.id
-  alert_rules = [thousandeyes_alert_rule.ldap_alert_rule.id]
-  server      = "${each.value.hostname}:${each.value.port}"
-  agents      = var.agent_ids
+  test_name          = "LDAP Check - ${each.value.name}"
+  url                = "${each.value.hostname}:${each.value.port}"
+  transaction_script = file("${path.module}/../ldap-monitor.js")
+  agents             = var.agent_ids
+  alert_rules        = [thousandeyes_alert_rule.ldap_alert_rule.rule_id]
+  interval           = 300
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,15 +1,15 @@
 output "monitoring_group_id" {
-  value = thousandeyes_group.monitoring_config.id
+  value = thousandeyes_account_group.monitoring_config.aid
 }
 
 output "monitoring_role_id" {
-  value = thousandeyes_role.monitoring_config_admin.id
+  value = thousandeyes_role.monitoring_config_admin.role_id
 }
 
 output "ldap_alert_rule_id" {
-  value = thousandeyes_alert_rule.ldap_alert_rule.id
+  value = thousandeyes_alert_rule.ldap_alert_rule.rule_id
 }
 
 output "ldap_test_ids" {
-  value = { for name, test in thousandeyes_transaction_test.ldap_test : name => test.id }
+  value = { for name, test in thousandeyes_web_transaction.ldap_test : name => test.test_id }
 }

--- a/terraform/permissions.tf
+++ b/terraform/permissions.tf
@@ -1,15 +1,17 @@
 resource "thousandeyes_role" "monitoring_config_admin" {
-  name        = "Monitoring Config Administrator"
-  description = "Role for managing LDAP monitoring resources"
+  name        = "Monitoring Administrator"
   permissions = [
-    "Edit tests",
+    "View tests",
+    "Edit tests and run instant tests",
+    "View alert rules",
     "Edit alert rules",
+    "View test templates",
     "Edit test templates",
-    "View all agents"
+    "View agents in account group"
   ]
 }
 
-resource "thousandeyes_group" "monitoring_config" {
-  name  = "ThousandEyes Monitoring Config"
-  roles = [thousandeyes_role.monitoring_config_admin.id]
+resource "thousandeyes_account_group" "monitoring_config" {
+  account_group_name = "ThousandEyes Monitoring Config"
+  # Note: This group will be used to assign users with the Monitoring Administrator role
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     thousandeyes = {
       source  = "thousandeyes/thousandeyes"
-      version = "~> 0.16.0"
+      version = ">= 3.0.0"
     }
   }
 }
 
 provider "thousandeyes" {
-  auth_token = var.te_api_token
+  token = var.te_api_token
 }

--- a/terraform/template.tf
+++ b/terraform/template.tf
@@ -1,6 +1,2 @@
-resource "thousandeyes_transaction_test" "ldap_template" {
-  test_name = "LDAP Monitor Template"
-  template  = true
-  script    = file("${path.module}/../ldap-monitor.js")
-  interval  = 300
-}
+# Template functionality is now handled directly in the web_transaction resource
+# through the transaction_script parameter


### PR DESCRIPTION
- Update provider version constraint from ~> 0.16.0 to >= 3.0.0
- Fix resource names and parameters for API v7 compatibility
  * thousandeyes_transaction_test → thousandeyes_web_transaction
  * thousandeyes_group → thousandeyes_account_group
  * Add required alert rule parameters (rounds_violating_required/out_of)
  * Update parameter names (script → transaction_script)
- Add proper permissions for Monitoring Administrator role per guide
  * View tests, Edit tests and run instant tests
  * View/Edit alert rules and test templates
  * View agents in account group
- Add .terraform.lock.hcl for provider version consistency
- Update .gitignore with Terraform best practices