### PR TITLE
Handle extra LDAP response types

### DIFF
--- a/ldap-monitor.js
+++ b/ldap-monitor.js
@@ -864,13 +864,33 @@ async function runTest() {
     }
     
     // Simplified search response validation
+    let firstTagPos = 8;
     if (searchRsp.length > 8) {
-      const responseType = searchRsp[8];
-      
+      let pos = 8;
+      let responseType = searchRsp[pos];
+
+      // Skip SearchResultReference (0x73), intermediateResponse (0x79)
+      // and context-specific tags (0xA0-0xBF)
+      while (
+        responseType === 0x73 ||
+        responseType === 0x79 ||
+        (responseType >= 0xa0 && responseType <= 0xbf)
+      ) {
+        const skipInfo = parseBerLength(searchRsp, pos + 1);
+        if (!skipInfo) break;
+        if (debugMode) {
+          console.log(`Debug: Skipping tag 0x${toHex(responseType)}`);
+        }
+        pos += 1 + skipInfo.bytesUsed + skipInfo.length;
+        if (pos >= searchRsp.length) break;
+        responseType = searchRsp[pos];
+      }
+      firstTagPos = pos;
+
       if (debugMode) {
         console.log(`Debug: Search response type: 0x${toHex(responseType)} (${searchRsp.length} bytes)`);
       }
-      
+
       // Handle main response types
       if (responseType === 0x65) {
         // SearchResultDone - this is what we expect for base scope
@@ -918,7 +938,7 @@ async function runTest() {
       } else if (responseType === 0x06) {
         // Check for result code in 0x06 response
         let foundResultCode = null;
-        for (let i = 8; i < searchRsp.length && i < 30; i++) {
+        for (let i = firstTagPos; i < searchRsp.length && i < firstTagPos + 22; i++) {
           if (searchRsp[i] === 0x0A && i + 1 < searchRsp.length) {
             foundResultCode = searchRsp[i + 1];
                 break;
@@ -950,13 +970,13 @@ async function runTest() {
     }
     
     if (doneIndex === -1) {
-      // If we didn't find SearchResultDone, but we got SearchResultDone at position 8, handle it
-      if (searchRsp.length > 8 && searchRsp[8] === 0x65) {
-        if (debugMode) console.log('Debug: SearchResultDone found at position 8');
-        
-        const directLengthInfo = parseBerLength(searchRsp, 9);
+      // If SearchResultDone wasn't found, check first tag position
+      if (searchRsp.length > firstTagPos && searchRsp[firstTagPos] === 0x65) {
+        if (debugMode) console.log(`Debug: SearchResultDone found at position ${firstTagPos}`);
+
+        const directLengthInfo = parseBerLength(searchRsp, firstTagPos + 1);
         if (directLengthInfo) {
-          const directResultCodePos = 9 + directLengthInfo.bytesUsed;
+          const directResultCodePos = firstTagPos + 1 + directLengthInfo.bytesUsed;
           if (searchRsp.length > directResultCodePos) {
             const directResultCode = searchRsp[directResultCodePos];
             if (debugMode) {

--- a/tasks.yml
+++ b/tasks.yml
@@ -1,0 +1,12 @@
+- id: 4
+  name: "Extend Response Type Handling"
+  context: |
+    The script currently handles 0x65, 0x64, 0x82 and 0x06. LDAP also defines SearchResultReference (0x73) and intermediateResponse. We need graceful handling for those tags.
+  prompt: |-
+    In the section that switches on `responseType = buffer[8]`, add cases to:
+      1. Detect tag 0x73 (SearchResultReference) and skip over its TLV using `parseBerLength`, continuing the scan.
+      2. Detect intermediateResponse (0x79) and treat it as non-fatal (skip).
+      3. For unknown but valid LDAP tags (context-specific 0xA0–0xBF), skip their TLV instead of throwing.
+      4. Keep the additional code under 1 KB to respect the overall character budget.
+  status: done
+


### PR DESCRIPTION
## Summary
- Skip LDAP SearchResultReference (0x73) entries and intermediateResponse (0x79)
- Ignore unknown context-specific LDAP tags (0xA0-0xBF)
- Track completed task in tasks.yml

## Testing
- `npm test`
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_689132f7c7a483219034b5441f98ceae