### PR TITLE
Handle LDAP server URLs without protocol prefixes

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -10,7 +10,7 @@ resource "thousandeyes_web_transaction" "ldap_test" {
   for_each = { for server in var.ldap_servers : server.name => server }
 
   test_name          = "LDAP Check - ${each.value.name}"
-  url                = "${each.value.hostname}:${each.value.port}"
+  url                = "ldaps://${each.value.hostname}:${each.value.port}"
   transaction_script = file("${path.module}/../ldap-monitor.js")
   agents             = var.agent_ids
   alert_rules        = [thousandeyes_alert_rule.ldap_alert_rule.rule_id]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,21 +10,21 @@ variable "te_user_email" {
 }
 
 variable "ldap_servers" {
-  description = "A list of LDAP servers to monitor."
+  description = "A list of LDAP servers to monitor. `hostname` should exclude any protocol prefix."
   type = list(object({
     name     = string
-    hostname = string
+    hostname = string # Hostname without protocol prefix
     port     = number
   }))
   default = [
     {
       name     = "Primary LDAP Server (DC1)"
-      hostname = "ldaps://dc1.example.com"
+      hostname = "dc1.example.com"
       port     = 636
     },
     {
       name     = "Secondary LDAP Server (DC2)"
-      hostname = "ldaps://dc2.example.com"
+      hostname = "dc2.example.com"
       port     = 636
     }
   ]


### PR DESCRIPTION
## Summary
- clarify that ldap_servers hostname should not include protocol
- explicitly prefix ldaps scheme when building LDAP monitor URLs

## Testing
- `npm test`
- `npm run lint`
- `npm run validate`
- `terraform fmt -check variables.tf monitoring.tf`
- `terraform init -backend=false` *(fails: Failed to query available provider packages: 403 Forbidden)*
- `terraform validate` *(fails: provider thousandeyes/thousandeyes 3.0.5 not cached)*


------
https://chatgpt.com/codex/tasks/task_e_68952bd7b2608321a8aaa553dca255e1